### PR TITLE
fix: Add start and build scripts to server/package.json

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
+    "build": "echo 'No build step required for server' && exit 0",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],


### PR DESCRIPTION
## Chore: Add Start and Build Scripts to Server

This PR introduces standard `start` and `build` scripts to the `server/package.json` file.

**Key Changes:**
- Added a `start` script to run `index.js` using Node.
- Added a `build` script that acts as a no-op, indicating no build step is required for the server.

**Review Notes:**
- These scripts facilitate easier local development and integration with CI/CD pipelines that expect standard script commands.